### PR TITLE
Add autoconf option for custom /etc/OpenCL/vendors .icd path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,8 @@ stamp-generator: icd_generator.rb
 
 # ignore the warning in OpenCL headers when using old interface
 libOpenCL_la_CFLAGS= $(NO_DEPRECATED_DECLARATIONS_FLAGS) \
-	$(AM_CFLAGS) $(PTHREAD_CFLAGS)
+	$(AM_CFLAGS) $(PTHREAD_CFLAGS) \
+	-DETC_OPENCL_VENDORS=\"@OCL_ICD_VENDORDIR@\"
 
 libOpenCL_la_SOURCES = ocl_icd_loader.c ocl_icd_loader.h ocl_icd_debug.h
 nodist_libOpenCL_la_SOURCES = ocl_icd_loader_gen.c ocl_icd.h

--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,14 @@ AC_ARG_ENABLE([update-database],
   [update_database=no])
 AM_CONDITIONAL([UPDATE_DATABASE], [test x"$update_database" != xno])
 
+# --enable-custom-vendordir
+AC_ARG_ENABLE([custom-vendordir],
+  [AS_HELP_STRING([--enable-custom-vendordir],
+                  [use the given directory instead of /etc/OpenCL/vendors to look for .icd files])],
+  [OCL_ICD_VENDORDIR=$enableval],
+  [OCL_ICD_VENDORDIR=/etc/OpenCL/vendors])
+AC_SUBST([OCL_ICD_VENDORDIR])
+
 # always use versionned symbols (check required for MacOSX)
 AM_CONDITIONAL([USE_MAP], [true])
 

--- a/configure.ac
+++ b/configure.ac
@@ -150,7 +150,7 @@ AC_ARG_ENABLE([custom-vendordir],
   [AS_HELP_STRING([--enable-custom-vendordir],
                   [use the given directory instead of /etc/OpenCL/vendors to look for .icd files])],
   [OCL_ICD_VENDORDIR=$enableval],
-  [OCL_ICD_VENDORDIR=/etc/OpenCL/vendors])
+  [OCL_ICD_VENDORDIR=$sysconfdir/OpenCL/vendors])
 AC_SUBST([OCL_ICD_VENDORDIR])
 
 # always use versionned symbols (check required for MacOSX)

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -28,3 +28,7 @@ libOpenCL.so.7: libOpenCL.7
 	@: already create by a2x when generating libOpenCL.7
 endif
 
+libOpenCL.7.txt: libOpenCL.7.txt.in
+	$(SED) \
+	    -e "s|[@]OCL_ICD_VENDORDIR@|@OCL_ICD_VENDORDIR@|g" \
+	    < "$<" > "$@"

--- a/doc/libOpenCL.7.txt.in
+++ b/doc/libOpenCL.7.txt.in
@@ -19,10 +19,12 @@ any OpenCL implementation itself, but merly act as a dispatcher to real OpenCL
 implementations provided as OpenCL Installable Client Driver (ICD).
 An ICD loader should be able to load ICDs provided by any vendors.
 
-According to OpenCL specifications from Khronos (see [Khronos]), the ICD Loader
-looks for files into '`/etc/OpenCL/vendors/`' directory and, for each file
+The ICD Loader will look for files in '`@OCL_ICD_VENDORDIR@`' directory and, for each file
 whose name ends with '`.icd`', the ICD Loader loads with **dlopen**(3) the
 shared library whose name is on the first line of the '`.icd`' file.
+According to OpenCL specifications from Khronos (see [Khronos]), the default
+path for this purpose is '`/etc/OpenCL/vendors`'. OCL-ICD will use this
+path if it is configured with the root directory as the installation prefix.
 
 Each shared library name in ".icd" files can have its path, or it can be a plain
 filename. In the latter case, the ICD shared library will be looked for into the
@@ -34,7 +36,7 @@ Some environment variables can be used modify the default behavior of
 libOpenCL.
 
 *OPENCL_VENDOR_PATH*::
-This variable allows one to modify the defaut '`/etc/OpenCL/vendors/`' path.
+This variable allows one to modify the defaut '`@OCL_ICD_VENDORDIR@`' path.
 It is compatible with some other ICD loaders (but not all of them, as the
 variable is not part of the standard). Note that *$OCL_ICD_VENDORS* (see below)
 is used in priority if defined and not empty.
@@ -44,7 +46,7 @@ This variable allows one to change the way ICD are searched on the system.
 Several cases are considered:
 
 a. if *$OCL_ICD_VENDORS* is a directory path, then this path replaces the
-  "/etc/OpenCL/vendors" path in the standard behavior: the loader will use the
+  "@OCL_ICD_VENDORDIR@" path in the standard behavior: the loader will use the
   '`.icd`' files in this directory;
 b. else, if *$OCL_ICD_VENDORS* ends with '`.icd`', libOpenCL.so will only load
   the ICD whose shared library name is wrote into the specified ".icd"
@@ -52,7 +54,7 @@ b. else, if *$OCL_ICD_VENDORS* ends with '`.icd`', libOpenCL.so will only load
   +
   If there is no slashes into
   *$OCL_ICD_VENDORS*, libOpenCL.so will first try to use
-  '`/etc/OpenCL/vendors/`'*$OCL_ICD_VENDORS* (or
+  '`@OCL_ICD_VENDORDIR@`'*$OCL_ICD_VENDORS* (or
   *$OPENCL_VENDOR_PATH*'`/`'*$OCL_ICD_VENDORS* if *OPENCL_VENDOR_PATH* is
   defined).
   If this fail or if there are shashes, it uses *$OCL_ICD_VENDORS* (as a

--- a/ocl_icd_loader.c
+++ b/ocl_icd_loader.c
@@ -49,8 +49,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define DEBUG_OCL_ICD_PROVIDE_DUMP_FIELD
 #include "ocl_icd_debug.h"
 
-#define ETC_OPENCL_VENDORS "/etc/OpenCL/vendors"
-
 int debug_ocl_icd_mask=0;
 
 typedef __typeof__(clGetPlatformInfo) *clGetPlatformInfo_fn;


### PR DESCRIPTION
I had a [need](https://github.com/inducer/ocl-icd-feedstock) to force ocl-icd to look for `.icd` files in a different spot by default. These changes make that happen. They're pretty minimally invasive and I thought they might potentially be useful for others.