### PR TITLE
icd_generator.rb: fix build failure against gcc-10

### DIFF
--- a/icd_generator.rb
+++ b/icd_generator.rb
@@ -207,7 +207,7 @@ EOF
     }
     libdummy_icd_structures += "};\n\n"
     libdummy_icd_structures += "#pragma GCC visibility push(hidden)\n\n"
-    libdummy_icd_structures += "struct _cl_icd_dispatch master_dispatch; \n\n"
+    libdummy_icd_structures += "extern struct _cl_icd_dispatch master_dispatch; \n\n"
     $use_name_in_test.each { |k, f|
       libdummy_icd_structures += "typeof(#{f}) INT#{f};\n"
     }


### PR DESCRIPTION
On gcc-10 (and gcc-9 -fno-common) build fails as:

```
libtool: link: gcc -shared  -fPIC -DPIC  .libs/libdummy_icd.o .libs/libdummy_icd_gen.o \
    -ldl  -g -O2   -Wl,-soname -Wl,libdummycl.so.0 -o .libs/libdummycl.so.0.0.0
ld: .libs/libdummy_icd_gen.o:/home/slyfox/dev/git/ocl-icd/libdummy_icd_gen.h:226:
  multiple definition of `master_dispatch'; .libs/libdummy_icd.o:/home/slyfox/dev/git/ocl-icd/libdummy_icd_gen.h:226: first defined here
```

gcc-10 will change the default from -fcommon to fno-common:
https://gcc.gnu.org/PR85678.

The error also happens if CFLAGS=-fno-common passed explicitly.

Reported-by: Anthony Parsons
Bug: https://bugs.gentoo.org/706098