### PR TITLE
FIX ABI issues.

### DIFF
--- a/ocl_icd_loader.c
+++ b/ocl_icd_loader.c
@@ -891,12 +891,12 @@ getDefaultPlatformID() {
   typeof(name) name##_hid __attribute__ ((alias (#name), visibility("hidden")))
 #endif
 
-typedef enum {
-  CL_ICDL_OCL_VERSION=1,
-  CL_ICDL_VERSION=2,
-  CL_ICDL_NAME=3,
-  CL_ICDL_VENDOR=4,
-} cl_icdl_info;
+typedef cl_uint cl_icdl_info;
+
+#define CL_ICDL_OCL_VERSION 1
+#define CL_ICDL_VERSION     2
+#define CL_ICDL_NAME        3
+#define CL_ICDL_VENDOR      4
 
 static cl_int clGetICDLoaderInfoOCLICD(
   cl_icdl_info     param_name,


### PR DESCRIPTION
Using enums, while safe in most place, can be an ABI issue due to compiler specific behavior regarding enums backing type. This removes the `cl_icld_info` `enum` type and maps it to a `cl_uint` to keep coherence with the rest of the OpenCL API/ABI.

This could break `clinfo` on 16bit big endian platforms if one exists.

I am keeping the test as it is currently. It should trigger on problematic platforms, hopefully someone will report such a platform.