### PR TITLE
Update pkg-config file to reflect new OpenCL-Headers pkgconfig support.

### DIFF
--- a/OpenCL.pc.in
+++ b/OpenCL.pc.in
@@ -5,6 +5,7 @@ includedir=@includedir@
 
 Name: OpenCL
 Description: Open Computing Language generic Installable Client Driver Loader
+Requires: OpenCL-Headers
 Version: @OPENCL_VERSION@
 Libs: -L${libdir} -lOpenCL
 Cflags: -I${includedir}

--- a/OpenCL.pc.in
+++ b/OpenCL.pc.in
@@ -8,4 +8,3 @@ Description: Open Computing Language generic Installable Client Driver Loader
 Requires: OpenCL-Headers
 Version: @OPENCL_VERSION@
 Libs: -L${libdir} -lOpenCL
-Cflags: -I${includedir}

--- a/ocl-icd.pc.in
+++ b/ocl-icd.pc.in
@@ -5,6 +5,7 @@ includedir=@includedir@
 
 Name: ocl-icd
 Description: Open Computing Language generic Installable Client Driver support
+Requires: OpenCL-Headers
 Version: @VERSION@
 Libs: -L${libdir}
 Cflags: -I${includedir}


### PR DESCRIPTION
OpenCL-Headers were recently updated with support for pkg-config, this change change both .pc files to require the OpenCL-Headers pkg-config module.