### PR TITLE
Add cllayerinfo tool

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,6 +56,15 @@ libOpenCL_la_DEPENDS = ocl_icd_loader_gen.map
 endif
 
 ####################################
+# A utility to list loaded layers
+bin_PROGRAMS = cllayerinfo
+
+cllayerinfo_SOURCES = cllayerinfo.c $(libOpenCL_la_SOURCES)
+nodist_cllayerinfo_SOURCES = $(nodist_libOpenCL_la_SOURCES)
+cllayerinfo_CFLAGS = -DCLLAYERINFO $(libOpenCL_la_CFLAGS)
+cllayerinfo_LDFLAGS = $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)
+
+####################################
 # A very small program test
 check_PROGRAMS=ocl_test ocl_test_icdl
 ocl_test_SOURCES = ocl_test.c

--- a/cllayerinfo.c
+++ b/cllayerinfo.c
@@ -1,0 +1,91 @@
+#include "ocl_icd_loader.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+int stdout_bak, stderr_bak;
+
+static inline int
+silence_fd(FILE *file, int fd)
+{
+  int new_fd, fd_bak;
+  fflush(file);
+  fd_bak = dup(fd);
+  new_fd = open("/dev/null", O_WRONLY);
+  dup2(new_fd, fd);
+  close(new_fd);
+  return fd_bak;
+}
+
+static inline void
+restore_fd(FILE *file, int fd, int fd_bak)
+{
+  fflush(file);
+  dup2(fd_bak, fd);
+  close(fd_bak);
+}
+
+static void silence_outputs(void)
+{
+  stdout_bak = silence_fd(stdout, 1);
+  stderr_bak = silence_fd(stderr, 2);
+}
+
+static void restore_outputs(void)
+{
+  restore_fd(stdout, 1, stdout_bak);
+  restore_fd(stderr, 2, stderr_bak);
+}
+
+void mute(void) {
+  silence_outputs();
+  atexit(restore_outputs);
+}
+
+void unmute(void) {
+  restore_outputs();
+  atexit(silence_outputs);
+}
+
+void print_layer_info(const struct layer_icd *layer)
+{
+  cl_layer_api_version api_version = 0;
+  clGetLayerInfo_fn layer_info_fn_ptr = (clGetLayerInfo_fn)layer->layer_info_fn_ptr;
+  cl_int error = CL_SUCCESS;
+  size_t sz;
+
+  printf("%s:\n", layer->library_name);
+  error = layer_info_fn_ptr(CL_LAYER_API_VERSION, sizeof(api_version), &api_version, NULL);
+  if (error == CL_SUCCESS)
+    printf("\tCL_LAYER_API_VERSION: %d\n", (int)api_version);
+
+  error = layer_info_fn_ptr(CL_LAYER_NAME, 0, NULL, &sz);
+  if (error == CL_SUCCESS)
+  {
+    char *name = (char *)malloc(sz);
+    if (name)
+    {
+      error = layer_info_fn_ptr(CL_LAYER_NAME, sz, name, NULL);
+      if (error == CL_SUCCESS)
+        printf("\tCL_LAYER_NAME: %s\n", name);
+      free(name);
+    }
+  }
+}
+
+int main (int argc, char *argv[])
+{
+  (void)argc;
+  (void)argv;
+  mute();
+  _initClIcd_no_inline();
+  unmute();
+  const struct layer_icd *layer = _first_layer;
+  while (layer)
+  {
+    print_layer_info(layer);
+    layer = layer->next_layer;
+  }
+  return 0;
+}

--- a/icd_generator.rb
+++ b/icd_generator.rb
@@ -350,6 +350,7 @@ EOF
     icd_layer_source = "/**\n#{$license}\n*/\n"
     icd_layer_source += <<EOF
 #include <stdio.h>
+#include <string.h>
 #define CL_USE_DEPRECATED_OPENCL_1_0_APIS
 #define CL_USE_DEPRECATED_OPENCL_1_1_APIS
 #define CL_USE_DEPRECATED_OPENCL_1_2_APIS
@@ -367,6 +368,8 @@ EOF
 
 static struct _cl_icd_dispatch dispatch = {NULL};
 static const struct _cl_icd_dispatch *tdispatch;
+static const cl_layer_api_version layer_api_version = CL_LAYER_API_VERSION_100;
+static const char layer_name[] = "dummylayer";
 
 CL_API_ENTRY cl_int CL_API_CALL
 clGetLayerInfo(
@@ -374,22 +377,30 @@ clGetLayerInfo(
     size_t         param_value_size,
     void          *param_value,
     size_t        *param_value_size_ret) {
+  size_t sz = 0;
+  const void *src = NULL;
   if (param_value_size && !param_value)
     return CL_INVALID_VALUE;
   if (!param_value && !param_value_size_ret)
     return CL_INVALID_VALUE;
   switch (param_name) {
   case CL_LAYER_API_VERSION:
-    if (param_value_size < sizeof(cl_layer_api_version))
-      return CL_INVALID_VALUE;
-    if (param_value)
-      *((cl_layer_api_version *)param_value) = CL_LAYER_API_VERSION_100;
-    if (param_value_size_ret)
-      *param_value_size_ret = sizeof(cl_layer_api_version);
+    sz = sizeof(cl_layer_api_version);
+    src = &layer_api_version;
+    break;
+  case CL_LAYER_NAME:
+    sz = sizeof(layer_name);
+    src = layer_name;
     break;
   default:
     return CL_INVALID_VALUE;
   }
+  if (param_value && param_value_size < sz)
+    return CL_INVALID_VALUE;
+  if (param_value)
+    memcpy(param_value, src, sz);
+  if (param_value_size_ret)
+    *param_value_size_ret = sz;
   return CL_SUCCESS;
 }
 

--- a/ocl_icd_loader.c
+++ b/ocl_icd_loader.c
@@ -57,24 +57,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 int debug_ocl_icd_mask=0;
 
-typedef cl_uint cl_layer_info;
-typedef cl_uint cl_layer_api_version;
-#define CL_LAYER_API_VERSION 0x4240
-#define CL_LAYER_API_VERSION_100 100
-
-typedef __typeof__(clGetPlatformInfo) *clGetPlatformInfo_fn;
-CL_API_ENTRY typedef cl_int (CL_API_CALL *clGetLayerInfo_fn)(
-    cl_layer_info  param_name,
-    size_t         param_value_size,
-    void          *param_value,
-    size_t        *param_value_size_ret);
-
-CL_API_ENTRY typedef cl_int (CL_API_CALL *clInitLayer_fn)(
-    cl_uint                         num_entries,
-    const struct _cl_icd_dispatch  *target_dispatch,
-    cl_uint                        *num_entries_out,
-    const struct _cl_icd_dispatch **layer_dispatch);
-
 static inline void dump_vendor_icd(const char* info, const struct vendor_icd *v) {
   debug(D_DUMP, "%s %p={ num=%i, handle=%p, f=%p}\n", info,
 	v, v->num_platforms, v->dl_handle, v->ext_fn_ptr);

--- a/ocl_icd_loader.c
+++ b/ocl_icd_loader.c
@@ -685,6 +685,10 @@ static void __initLayer(char * layer_path) {
     for( i = limit; i <= OCL_ICD_LAST_FUNCTION; i++) {
       ((void **)&(new_layer->dispatch))[i] = ((void **)target_dispatch)[i];
     }
+#ifdef CLLAYERINFO
+  new_layer->library_name = strdup(layer_path);
+  new_layer->layer_info_fn_ptr = clGetLayerInfo_ptr;
+#endif
   } else {
     debug(D_WARN, "Layer: %s could not be loaded", layer_path);
   }

--- a/ocl_icd_loader.h
+++ b/ocl_icd_loader.h
@@ -43,6 +43,24 @@ cl_platform_id selectPlatformID(cl_platform_id pid) {
   return getDefaultPlatformID();
 }
 
+typedef cl_uint cl_layer_info;
+typedef cl_uint cl_layer_api_version;
+#define CL_LAYER_API_VERSION 0x4240
+#define CL_LAYER_API_VERSION_100 100
+
+typedef __typeof__(clGetPlatformInfo) *clGetPlatformInfo_fn;
+CL_API_ENTRY typedef cl_int (CL_API_CALL *clGetLayerInfo_fn)(
+    cl_layer_info  param_name,
+    size_t         param_value_size,
+    void          *param_value,
+    size_t        *param_value_size_ret);
+
+CL_API_ENTRY typedef cl_int (CL_API_CALL *clInitLayer_fn)(
+    cl_uint                         num_entries,
+    const struct _cl_icd_dispatch  *target_dispatch,
+    cl_uint                        *num_entries_out,
+    const struct _cl_icd_dispatch **layer_dispatch);
+
 struct layer_icd;
 struct layer_icd {
   void                    *dl_handle;

--- a/ocl_icd_loader.h
+++ b/ocl_icd_loader.h
@@ -46,6 +46,7 @@ cl_platform_id selectPlatformID(cl_platform_id pid) {
 typedef cl_uint cl_layer_info;
 typedef cl_uint cl_layer_api_version;
 #define CL_LAYER_API_VERSION 0x4240
+#define CL_LAYER_NAME        0x4241
 #define CL_LAYER_API_VERSION_100 100
 
 typedef __typeof__(clGetPlatformInfo) *clGetPlatformInfo_fn;
@@ -66,6 +67,10 @@ struct layer_icd {
   void                    *dl_handle;
   struct _cl_icd_dispatch  dispatch;
   struct layer_icd        *next_layer;
+#ifdef CLLAYERINFO
+  char                    *library_name;
+  void                    *layer_info_fn_ptr;
+#endif
 };
 
 __attribute__((visibility("hidden"))) extern struct layer_icd *_first_layer;

--- a/ocl_icd_loader.h
+++ b/ocl_icd_loader.h
@@ -50,13 +50,13 @@ typedef cl_uint cl_layer_api_version;
 #define CL_LAYER_API_VERSION_100 100
 
 typedef __typeof__(clGetPlatformInfo) *clGetPlatformInfo_fn;
-CL_API_ENTRY typedef cl_int (CL_API_CALL *clGetLayerInfo_fn)(
+typedef cl_int (CL_API_CALL *clGetLayerInfo_fn)(
     cl_layer_info  param_name,
     size_t         param_value_size,
     void          *param_value,
     size_t        *param_value_size_ret);
 
-CL_API_ENTRY typedef cl_int (CL_API_CALL *clInitLayer_fn)(
+typedef cl_int (CL_API_CALL *clInitLayer_fn)(
     cl_uint                         num_entries,
     const struct _cl_icd_dispatch  *target_dispatch,
     cl_uint                        *num_entries_out,

--- a/tests/testsuite-standard.at
+++ b/tests/testsuite-standard.at
@@ -100,3 +100,12 @@ vendor: OCL Icd free software
 ], [])
 AT_CLEANUP
 
+AT_SETUP([Our dummy layer through cllayerinfo])
+AT_EXPORT([OPENCL_LAYERS],[$abs_top_builddir/.libs/libdummylayer.so],
+	  [OCL_ICD_VENDORS],[$abs_top_builddir/vendors])
+AT_CHECK_UNQUOTED([cllayerinfo], 0,
+[$abs_top_builddir/.libs/libdummylayer.so:
+	CL_LAYER_API_VERSION: 100
+	CL_LAYER_NAME: dummylayer
+], [])
+AT_CLEANUP


### PR DESCRIPTION
This adds the cllayerinfo tool that was added to the official ICD loader. It is important that each loader have it's own version of the tool as subtle difference between loader behavior could meaningfully impact layer configuration. The tool embeds the loader library code to load drivers and layers and then prints the list of loaded layer and their information. As of now, the layer library path, layer API version, and layer name are supported.