### PR TITLE
Add CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES define

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,7 @@ stamp-generator: icd_generator.rb
 # ignore the warning in OpenCL headers when using old interface
 libOpenCL_la_CFLAGS= $(NO_DEPRECATED_DECLARATIONS_FLAGS) \
 	$(AM_CFLAGS) $(PTHREAD_CFLAGS) \
+	-DCL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES \
 	-DETC_OPENCL_VENDORS=\"@OCL_ICD_VENDORDIR@\" \
 	-DETC_OPENCL_LAYERS=\"@OCL_ICD_LAYERDIR@\"
 


### PR DESCRIPTION
New OpenCL headers declare function prototypes for extensions, even for ones not present in the loader. They can be deactivated with the use of the `CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES` preprocessor macro.